### PR TITLE
Renamed Session model to Retro

### DIFF
--- a/src/app/models/group.ts
+++ b/src/app/models/group.ts
@@ -1,13 +1,11 @@
 export class Group {
-  id: number;
   name: string;
-  phaseId: number;
-  sessionId: string;
+  phaseId: string;
+  retroId: string;
 
-  constructor(id: number, name: string, phaseId: number, sessionId: string) {
-    this.id = id;
+  constructor(name: string, phaseId: string, retroId: string) {
     this.name = name;
     this.phaseId = phaseId;
-    this.sessionId = sessionId;
+    this.retroId = retroId;
   }
 }

--- a/src/app/models/message.ts
+++ b/src/app/models/message.ts
@@ -1,15 +1,13 @@
 export class Message {
-  id: number;
   text: string;
-  groupId: number;
-  phaseId: number;
-  sessionId: string;
+  groupId: string;
+  phaseId: string;
+  retroId: string;
 
-  constructor(id: number, text: string, groupId: number, phaseId: number, sessionId: string) {
-    this.id = id;
+  constructor(text: string, groupId: string, phaseId: string, retroId: string) {
     this.text = text;
     this.groupId = groupId;
     this.phaseId = phaseId;
-    this.sessionId = sessionId;
+    this.retroId = retroId;
   }
 }

--- a/src/app/models/phase.ts
+++ b/src/app/models/phase.ts
@@ -1,11 +1,9 @@
 export class Phase {
-  id: number;
   name: string;
-  sessionId: string;
+  retroId: string;
 
-  constructor(id: number, name: string, sessionId: string) {
-    this.id = id;
+  constructor(name: string, retroId: string) {
     this.name = name;
-    this.sessionId = sessionId;
+    this.retroId = retroId;
   }
 }

--- a/src/app/models/retro.ts
+++ b/src/app/models/retro.ts
@@ -1,12 +1,10 @@
-export class Session {
-  id: number;
+export class Retro {
   name: string;
   isActive: boolean;
   currentStep: number;
   votesPerParticipant: number;
 
-  constructor(id: number, name: string, isActive: boolean, currentStep: number, votesPerParticipant: number) {
-    this.id = id;
+  constructor(name: string, isActive: boolean, currentStep: number, votesPerParticipant: number) {
     this.name = name;
     this.isActive = isActive;
     this.currentStep = currentStep;

--- a/src/app/models/vote.ts
+++ b/src/app/models/vote.ts
@@ -1,10 +1,8 @@
 export class Vote {
-  id: number;
-  groupId: number;
+  groupId: string;
   userId: string;
 
-  constructor(id: number, groupId: number, userId: string) {
-    this.id = id;
+  constructor(groupId: string, userId: string) {
     this.groupId = groupId;
     this.userId = userId;
   }


### PR DESCRIPTION
- Renamed Session model to Retro 
- Changed foreign keys on models to be strings (which will reference the database key IDs that firebase generates)
- Removed ID from each model which would just reference the database key