### PR TITLE
Bug fix when joining retro

### DIFF
--- a/src/app/components/retro/retro.component.ts
+++ b/src/app/components/retro/retro.component.ts
@@ -102,6 +102,9 @@ export class RetroComponent implements OnInit {
   }
 
   toggleAdminToolbar() {
-    this.showAdminToolbar = this.retroSnapshot.isActive && this.user.auth.uid === this.retroSnapshot.adminId;
+    this.showAdminToolbar =
+      this.retroSnapshot.isActive
+      && this.user
+      && this.user.auth.uid === this.retroSnapshot.adminId;
   }
 }


### PR DESCRIPTION
Fixes error received when trying to join an active retro:

> Cannot read property 'auth' of null