### PR TITLE
Miscellaneous updates for Group Feedback

### DIFF
--- a/src/app/components/phase-steps/group-feedback/group-feedback.component.html
+++ b/src/app/components/phase-steps/group-feedback/group-feedback.component.html
@@ -4,9 +4,12 @@
     <div fxLayout>
       <div fxFlex="50%">
         <h2>Groups</h2>
-        <md-input-container *ngIf="allowAdminFunctions" style="width: 90%">
-          <input mdInput placeholder="Enter a new group name" [(ngModel)]="newGroupName" name="newGroupNameInput" (keyup.enter)="createNewGroup(newGroupName)" />
+        <md-input-container *ngIf="allowAdminFunctions" style="width: 85%">
+          <input mdInput placeholder="Enter a new group name" [(ngModel)]="newGroupName" name="newGroupNameInput" />
         </md-input-container>
+        <button md-icon-button *ngIf="allowAdminFunctions" (click)="createNewGroup(newGroupName)" width="15%">
+          <md-icon>add_box</md-icon>
+        </button>
         <div style="max-height: 60vh; overflow-y: auto">
           <div *ngFor="let groupItem of groups">
             <group (editingNotifier)="onNotify($event)"[groupName]="groupItem.name" [groupId]="groupItem.$key" [messages]="feedbackMessages" [enabledGroup]="enabledGroup" [allowAdminFunctions]="allowAdminFunctions"></group>

--- a/src/app/components/phase-steps/group-feedback/group-feedback.component.html
+++ b/src/app/components/phase-steps/group-feedback/group-feedback.component.html
@@ -7,7 +7,7 @@
         <md-input-container *ngIf="allowAdminFunctions" style="width: 90%">
           <input mdInput placeholder="Enter a new group name" [(ngModel)]="newGroupName" name="newGroupNameInput" (keyup.enter)="createNewGroup(newGroupName)" />
         </md-input-container>
-        <div style="max-height: 500px; overflow-y: auto">
+        <div style="max-height: 60vh; overflow-y: auto">
           <div *ngFor="let groupItem of groups">
             <group (editingNotifier)="onNotify($event)"[groupName]="groupItem.name" [groupId]="groupItem.$key" [messages]="feedbackMessages" [enabledGroup]="enabledGroup" [allowAdminFunctions]="allowAdminFunctions"></group>
           </div>
@@ -15,7 +15,7 @@
       </div>
       <div fxFlex="50%">
         <h2>Ungrouped Feedback</h2>
-        <div style="max-height: 550px; overflow-y: auto">
+        <div style="max-height: 70vh; overflow-y: auto">
           <app-feedback-container>
             <app-feedback-card *ngFor="let feedback of ungroupedFeedbackMessages" [feedback]="feedback" [enabledGroup]="enabledGroup"></app-feedback-card>
           </app-feedback-container>

--- a/src/app/components/phase-steps/group-feedback/group-feedback.component.ts
+++ b/src/app/components/phase-steps/group-feedback/group-feedback.component.ts
@@ -79,9 +79,11 @@ export class GroupFeedbackComponent implements OnInit, OnDestroy {
   }
 
   createNewGroup(newGroupName: string) {
-    let group = new Group(newGroupName, this.retro.currentPhaseId, this.retro.$key);
-    this.groupsObservable.push(group);
-    this.newGroupName = '';
+    if (newGroupName) {
+      let group = new Group(newGroupName, this.retro.currentPhaseId, this.retro.$key);
+      this.groupsObservable.push(group);
+      this.newGroupName = '';
+    }
   }
 
   onNotify(groupId: string) {


### PR DESCRIPTION
- Replaced trigger to create new groups (formerly a keystroke event) with a button
- Fixed scrolling of group and ungrouped feedback columns to enable based on the browser window size
- Preventing user from creating groups with blank names